### PR TITLE
Getting started on the Cloud-in-a-Box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ accessible systems.**
 * System is ready for use, by default DHCP is tried on
   the 1st network device
 * Login via ``dragon`` and ``password``
+* There is a ``wireguard-client.conf`` that you can copy over to a client
+  to create a tunnel to access to the web interfaces and APIs of the system.
+  On the client, adjust the client IP in it (if you want to connect with multiple
+  clients, otherwise leave it alone), copy it to ``/etc/wireguard/wg0.conf`` and
+  ``wg-quick up wg0`` to start the tunnel.
+* Point your browser to the [homer dashboard](https://homer.services.in-a-box.cloud/) for
+  the admin web interfaces.
+* The installation is a minimalistic single-node installation similar to the
+  testbed installation. Consult the [testbed documentation](https://docs.osism.de/testbed/)
+  for an overview over the system. Default passwords can be found
+  [here](https://docs.osism.de/testbed/usage.html#webinterfaces).
 
 ## Notes
 


### PR DESCRIPTION
A few more words on:
* wireguard-client.conf
* Pointer to testbed docu
* homer dashboard

As soon as we have a more comprehensive CiaB getting started guide, we would link that of course. For now, this seems useful to save research to get going.

Signed-off-by: Kurt Garloff <kurt@garloff.de>