### PR TITLE
Add prepare.sh script

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+firstip_address=$(hostname --all-ip-addresses | awk '{print $1}')
+first_network_interface=$(ip -br -4 a sh | grep ${firstip_address} | awk '{print $1}')
+
+find /opt/configuration -type f -exec sed -i "s/eno1/${first_network_interface}/g" {} \;


### PR DESCRIPTION
This script sets the correct interface name in the /opt/configuration directory.

Signed-off-by: Christian Berendt <berendt@osism.tech>