### PR TITLE
Disable netbox second try

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,7 +48,6 @@ chmod o+rw /var/run/docker.sock
 find /opt/configuration -type f -exec sed -i "s/eno1/${first_network_interface}/g" {} \;
 
 ./run.sh traefik
-./run.sh netbox
 ./run.sh manager
 
 popd

--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -38,7 +38,7 @@ ara_server_traefik: true
 ##########################
 # netbox
 
-enable_netbox: true
+enable_netbox: false
 
 netbox_host: "netbox.services.in-a-box.cloud"
 netbox_api_url: "https://{{ netbox_host }}"

--- a/environments/manager/secrets.yml
+++ b/environments/manager/secrets.yml
@@ -1,4 +1,2 @@
 ---
-netbox_api_token: "0000000000000000000000000000000000000000"
-
 manager_listener_broker_password: BO6yGAAq9eqA7IKqeBdtAEO7aJuNu4zfbhtnRo8Y


### PR DESCRIPTION
The Netbox only makes sense in the context of Ironic. Therefore, it can be deactivated in the CiaB.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
Co-authored-by: Christian Berendt <berendt@osism.tech>
