### PR TITLE
Sync with cfg-generics

### DIFF
--- a/environments/manager/images.yml
+++ b/environments/manager/images.yml
@@ -10,7 +10,7 @@ ara_server_image: "{{ docker_registry_ansible|default('quay.io') }}/osism/ara-se
 mariadb_tag: "10.9.3"
 mariadb_image: "{{ docker_registry }}/library/mariadb:{{ mariadb_tag }}"
 
-netbox_tag: "v3.2.5-ldap"
+netbox_tag: "v3.4.2"
 netbox_image: "{{ docker_registry_netbox|default('quay.io') }}/osism/netbox:{{ netbox_tag }}"
 
 nginx_tag: "1.23.2-alpine"


### PR DESCRIPTION
MANAGER_VERSION=4.2.0 gilt overlay

The Netbox version was wrong. A sync against cfg-generics with the corresponding manager version solves the problem and brings environments/manager to the correct state.

Signed-off-by: Christian Berendt <berendt@osism.tech>