### PR TITLE
openstack: add bootstrap-images playbook

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -50,4 +50,13 @@ osism apply wireguard
 sed -i -e s/WIREGUARD_PUBLIC_IP_ADDRESS/$(hostname --all-ip-addresses | awk '{print $1}')/ /home/dragon/wireguard-client.conf
 
 osism apply --environment openstack bootstrap
-osism manage images --cloud admin --name "Cirros"
+
+# osism manage images is only available since 4.3.0. To enable the
+# testbed to be used with < 4.3.0, here is this check.
+MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
+if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" ]]; then
+    osism apply --environment openstack bootstrap-images
+else
+    osism manage images --cloud admin --filter Cirros
+    osism manage images --cloud admin --name "Ubuntu 22.04 Minimal"
+fi

--- a/environments/openstack/playbook-bootstrap-images.yml
+++ b/environments/openstack/playbook-bootstrap-images.yml
@@ -1,0 +1,72 @@
+---
+# This playbook is only used for OSISM < 4.3.0. From 4.3.0 osism manage
+# images is available for this purpose.
+- name: Manage images
+  hosts: localhost
+  connection: local
+
+  vars:
+    url_ubuntu_image: https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
+    url_cirros_image: https://github.com/cirros-dev/cirros/releases/download/0.6.0/cirros-0.6.0-x86_64-disk.img
+
+  tasks:
+    - name: Download cirros image
+      ansible.builtin.get_url:
+        url: "{{ url_cirros_image }}"
+        dest: /tmp/cirros.img
+        mode: 0644
+
+    - name: Upload cirros image
+      openstack.cloud.image:
+        cloud: admin
+        state: present
+        name: "Cirros 0.6.0"
+        is_public: true
+        container_format: bare
+        disk_format: qcow2
+        filename: /tmp/cirros.img
+        min_disk: 1
+        properties:
+          cpu_arch: x86_64
+          distro: ubuntu
+          hw_rng_model: virtio
+
+    - name: Download ubuntu minimal 22.04 image
+      ansible.builtin.get_url:
+        url: "{{ url_ubuntu_image }}"
+        dest: /tmp/ubuntu.img
+        mode: 0644
+
+    - name: Get timestamp from the system
+      ansible.builtin.command: "date +%Y-%m-%d"
+      register: date
+      changed_when: false
+
+    - name: Upload ubuntu minimal 22.04 image
+      openstack.cloud.image:
+        cloud: admin
+        state: present
+        name: "Ubuntu 22.04"
+        is_public: true
+        container_format: bare
+        disk_format: qcow2
+        filename: /tmp/ubuntu.img
+        min_disk: 3
+        min_ram: 512
+        properties:
+          architecture: x86_64
+          cpu_arch: x86_64
+          distro: ubuntu
+          hw_disk_bus: scsi
+          hw_rng_model: virtio
+          hw_scsi_model: virtio-scsi
+          hypervisor_type: kvm
+          # NOTE: The upload date is taken at this point. The Ubuntu upstream images are rotated and not archived.
+          image_build_date: "{{ date.stdout }}"
+          image_description: https://launchpad.net/cloud-images
+          image_original_user: ubuntu
+          image_source: "{{ url_ubuntu_image }}"
+          os_distro: ubuntu
+          os_version: "22.04"
+          replace_frequency: never
+          uuid_validity: forever


### PR DESCRIPTION
This way it is possible to also manage the images on older manager versions.

Signed-off-by: Christian Berendt <berendt@osism.tech>