### PR TITLE
Fix masquerading

### DIFF
--- a/environments/openstack/playbook-bootstrap.yml
+++ b/environments/openstack/playbook-bootstrap.yml
@@ -9,14 +9,14 @@
       become: true
       ansible.builtin.iptables:
         chain: FORWARD
-        in_interface: "{{ network_internal_interface }}"
+        in_interface: "{{ network_mgmt_interface }}"
         jump: ACCEPT
 
     - name: Accept FORWARD on the management interface (outgoing)
       become: true
       ansible.builtin.iptables:
         chain: FORWARD
-        out_interface: "{{ network_internal_interface }}"
+        out_interface: "{{ network_mgmt_interface }}"
         jump: ACCEPT
 
     - name: Masquerade traffic on the management interface
@@ -24,7 +24,7 @@
       ansible.builtin.iptables:
         table: nat
         chain: POSTROUTING
-        out_interface: "{{ network_internal_interface }}"
+        out_interface: "{{ network_mgmt_interface }}"
         jump: MASQUERADE
 
 - name: Create SCS flavors

--- a/inventory/group_vars/generic/network.yml
+++ b/inventory/group_vars/generic/network.yml
@@ -4,7 +4,7 @@
 
 network_internal_interface: vlan100
 network_mgmt_interface: eno1
-network_workload_interface: vlan101
+network_workload_interface: vxlan0
 
 network_type: netplan
 
@@ -18,6 +18,9 @@ network_vlans:
     link: "{{ network_mgmt_interface }}"
     addresses:
       - "192.168.16.{{ node_id }}/24"
-  vlan101:
-    id: 101
-    link: "{{ network_mgmt_interface }}"
+
+network_dispatcher_scripts:
+  - src: /opt/configuration/network/vxlan.sh
+    dest: routable.d/vxlan.sh
+  - src: /opt/configuration/network/iptables.sh
+    dest: routable.d/iptables.sh

--- a/network/iptables.sh
+++ b/network/iptables.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ $IFACE == "{{ network_mgmt_interface }}" ]]; then
+    iptables -A FORWARD -i {{ network_mgmt_interface }} -j ACCEPT
+    iptables -A FORWARD -o {{ network_mgmt_interface }} -j ACCEPT
+    iptables -t nat -A POSTROUTING -o {{ network_mgmt_interface }} -j MASQUERADE
+fi

--- a/network/vxlan.sh
+++ b/network/vxlan.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ $IFACE == "{{ network_mgmt_interface }}" ]]; then
+    ip link add vxlan0 type vxlan id 42 group 239.1.1.1 dstport 4789 dev {{ network_mgmt_interface }}
+    ip addr add {{ '192.168.112.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}/20 dev vxlan0
+    ip link set up dev vxlan0
+fi


### PR DESCRIPTION
The management interface instead of the internal interface has to be masqueraded.

Closes osism/cloud-in-a-box#17

Signed-off-by: Christian Berendt <berendt@osism.tech>