### PR TITLE
Adapt wireguard configuration

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -47,6 +47,13 @@ osism apply openstackclient
 osism apply phpmyadmin
 
 osism apply wireguard
+
+# On OSISM < 5.0.0 this file is not yet present.
+if [[ -e /home/dragon/wg0-dragon.conf ]]; then
+    mv /home/dragon/wg0-dragon.conf /home/dragon/wireguard-client.conf
+fi
+
+sed -i -e "s/CHANGEME - dragon private key/GEQ5eWshKW+4ZhXMcWkAAbqzj7QA9G64oBFB3CbrR0w=/" /home/dragon/wireguard-client.conf
 sed -i -e s/WIREGUARD_PUBLIC_IP_ADDRESS/$(hostname --all-ip-addresses | awk '{print $1}')/ /home/dragon/wireguard-client.conf
 
 sudo ip addr add dev br-ex 192.168.112.10/24

--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -52,7 +52,11 @@ traefik_port_http: 1080
 ##########################
 # wireguard
 
-wireguard_allowed_client_ips: 192.168.16.0/24, 192.168.112.0/24
-wireguard_allowed_server_ips: 192.168.17.0/24
-wireguard_client_address: 192.168.17.4/24
+wireguard_client_allowed_ips: 192.168.16.0/24, 192.168.112.0/24
 wireguard_server_address: 192.168.17.5/24
+
+wireguard_users:
+  - name: dragon
+    key: LDweUZxqy/0AieSVw3baZmbRMPBqhfDUcuLAwSYyQkE=
+    ip: 192.168.17.4
+wireguard_create_client_config: true


### PR DESCRIPTION
The wireguard role has been refactored, adapt the configuration to the new parameters. Use the same key as within the testbed for consistency.