### PR TITLE
manager: enable flower service

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -20,6 +20,7 @@ manager_listener_broker_uri: "{% for host in manager_listener_broker_hosts %}amq
 # celery
 
 enable_celery: true
+flower_enable: true
 
 flower_traefik: true
 flower_host: flower.services.in-a-box.cloud


### PR DESCRIPTION
Has been disabled by default in OSISM 5.