### PR TITLE
Remove ceph workaround with device_health_metrics

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -60,7 +60,6 @@ osism apply ceph -e enable_ceph_mds=true -e enable_ceph_rgw=true
 osism apply copy-ceph-keys
 osism apply cephclient
 osism apply ceph-bootstrap-dashboard
-ceph osd pool set device_health_metrics crush_rule replicated_rule_ciab
 
 osism apply keystone
 osism apply horizon


### PR DESCRIPTION
Looks like this is not longer required after the change of the failure domain from hosts to devices.