### PR TITLE
Improvements for the bootstrap procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ironic-agent.kernel
 ironic-agent.initramfs
+*.swo
+*.swp

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
+
+BASE_DIR="$(dirname $(readlink -f $0))"
+source $BASE_DIR/include.sh
+
 set -x
 set -e
 
-firstip_address=$(hostname --all-ip-addresses | awk '{print $1}')
-first_network_interface=$(ip -br -4 a sh | grep ${firstip_address} | awk '{print $1}')
+default_gateway_interface="$(get_ethernet_interface_of_default_gateway)"
+get_default_gateway_settings
 
-find /opt/configuration -type f -exec sed -i "s/eno1/${first_network_interface}/g" {} \;
+find /opt/configuration -type f -exec sed -i "s/eno1/${default_gateway_interface}/g" {} +
+
+echo "PREPARE COMPLETE"

--- a/releasenotes/notes/improve-nic-handling-369df0b6e38e8c6b.yaml
+++ b/releasenotes/notes/improve-nic-handling-369df0b6e38e8c6b.yaml
@@ -1,0 +1,15 @@
+---
+prelude: >
+    improve external NIC handling
+features:
+  - discover the external-interface and -ip by using information from
+    the default route provided by the dhcp-client
+    (sort interface lexically and use the first one if there are multiple default routes)
+  - add infinite wait for a functional uplink connection
+other:
+  - |
+    Add other notes here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.

--- a/releasenotes/notes/refactor-ciab-installation-e2341960ba39e618.yaml
+++ b/releasenotes/notes/refactor-ciab-installation-e2341960ba39e618.yaml
@@ -1,0 +1,10 @@
+---
+prelude: >
+    Refactor installation shell scripts to improve maintainability
+features:
+  - log the entire installation script output to a logfile
+    (/var/log/install-cloud-in-a-box.log)
+  - improve debug output
+other:
+  - reduce the time for text replacements
+  - move common functionalities to a central include file

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
+
+
+BASE_DIR="$(dirname $(readlink -f $0))"
+source $BASE_DIR/include.sh
+
 set -x
 set -e
 
 export INTERACTIVE=false
 source /etc/cloud-in-a-box.env
 
-wait_for_container_healthy() {
-    local max_attempts="$1"
-    local name="$2"
-    local attempt_num=1
-
-    until [[ "$(/usr/bin/docker inspect -f '{{.State.Health.Status}}' $name)" == "healthy" ]]; do
-        if (( attempt_num++ == max_attempts )); then
-            return 1
-        else
-            sleep 5
-        fi
-    done
-}
 
 # The upgrade of Docker must be done on the manager via script because the docker service is restarted.
 # In the future, an "osism update docker" wrapper similar to the "osism update manager" wrapper


### PR DESCRIPTION
- wait for a working uplink in bootstrap.sh and deploy.sh
- add a funcionality to log the entire output to a logfile
   (for debugging purposes)
- improve the runtime of the interface
   replacement from ~70sec to ~6.5sec
- discover the interface by analyzing the default routes (`ip route ls`), take the first default route
- refactoring: move common functions to include.sh
