### PR TITLE
Change traefik https port from 443 to 10443

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -48,6 +48,7 @@ phpmyadmin_traefik: true
 traefik_enable: true
 traefik_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
 traefik_port_http: 1080
+traefik_port_https: 10443
 
 ##########################
 # wireguard


### PR DESCRIPTION
Required because the Horizon service is also running on port 443.