### PR TITLE
openstack: in the test play do not build port in advance

### DIFF
--- a/environments/openstack/playbook-test.yml
+++ b/environments/openstack/playbook-test.yml
@@ -132,15 +132,6 @@
         name: test
         public_key_file: /opt/configuration/environments/openstack/id_rsa.test.pub
 
-    - name: Create test port
-      openstack.cloud.port:
-        name: test-port
-        network: test
-        cloud: test
-        state: present
-        fixed_ips:
-          - ip_address: 192.168.200.10
-
     - name: Create test instance
       openstack.cloud.server:
         cloud: test
@@ -153,8 +144,7 @@
         security_groups:
           - icmp
           - ssh
-        nics:
-          - port-name: test-port
+        network: test
         boot_from_volume: true
         terminate_volume: true
         volume_size: 1


### PR DESCRIPTION
Related to osism/testbed/#2031