### PR TITLE
kolla: only use OVN for octavia

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,12 +48,6 @@ chmod o+rw /var/run/docker.sock
 
 find /opt/configuration -type f -exec sed -i "s/eno1/${default_gateway_interface}/g" {} +
 
-if [[ $CLOUD_IN_A_BOX_TYPE == "edge" ]]; then
-    sed -i "/octavia_network_type:/d" /opt/configuration/environments/kolla/configuration.yml
-    echo 'octavia_provider_drivers: "ovn:OVN provider"' >> /opt/configuration/environments/kolla/configuration.yml
-    echo 'octavia_provider_agents: ovn' >> /opt/configuration/environments/kolla/configuration.yml
-fi
-
 ./run.sh traefik
 
 if [[ $CLOUD_IN_A_BOX_TYPE == "sandbox" ]]; then

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -44,7 +44,8 @@ nova_libvirt_logging_debug: "no"
 nova_console: novnc
 
 # octavia
-octavia_network_type: tenant
+octavia_provider_drivers: "ovn:OVN provider"
+octavia_provider_agents: ovn
 
 # designate
 designate_ns_record: cloud.in-a-box.cloud


### PR DESCRIPTION
To avoid confusion and due to the limited resources we have, only OVN is now supported as a backend for Octavia.