### PR TITLE
Make all DNS records usable again

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -47,8 +47,6 @@ phpmyadmin_traefik: true
 
 traefik_enable: true
 traefik_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
-traefik_port_http: 1080
-traefik_port_https: 10443
 
 ##########################
 # wireguard

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -53,6 +53,13 @@ designate_ns_record: cloud.in-a-box.cloud
 # horizon
 horizon_keystone_multidomain: true
 
+# On the Cloud in a Box, we have an overlap with Traefik on port 80
+# on the internal interface. Therefore we move the internal port of
+# Horizon to port 1080. Horizon is accessed via the load balancer on
+# the external IP address. Therefore, nothing changes when accessing
+# Horizon itself.
+horizon_port: 1080
+
 # rgw integration
 enable_ceph_rgw: true
 enable_ceph_rgw_keystone: true


### PR DESCRIPTION
By moving Horizon to port 1080 and Traefik back to the standard ports, everything is as it should be.

Related to 9d3ecddf087dfd541d066dc143f62f6a9259a727