### PR TITLE
Prepare Netbox configuration for OSISM 7

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -30,8 +30,9 @@ homer_url_vault: ""
 ##########################
 # netbox
 
-netbox_host: netbox.services.in-a-box.cloud
 netbox_traefik: true
+netbox_host: netbox.services.in-a-box.cloud
+
 netbox_plugins_extra:
   - netbox_bgp
   - netbox_dns

--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -41,7 +41,12 @@ ara_server_traefik: true
 netbox_enable: true
 
 netbox_host: "netbox.services.in-a-box.cloud"
+netbox_traefik: true
 netbox_api_url: "https://{{ netbox_host }}"
+
+netbox_plugins_extra:
+  - netbox_bgp
+  - netbox_dns
 
 #########################
 # opensearch


### PR DESCRIPTION
By moving the Netbox service between the environments, all parameters must currently be present in both environments.