### PR TITLE
Get error output a bit more convenient

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "add_status 'error' 'BOOTSTRAP FAILED'" TERM INT EXIT
+trap "set +x; add_status 'error' 'BOOTSTRAP FAILED'; sleep 90" TERM INT EXIT
 set -e
 set -x
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "set +x; add_status 'error' 'DEPLOY FAILED'" TERM INT EXIT
+trap "set +x; add_status 'error' 'DEPLOY FAILED'; sleep 90" TERM INT EXIT
 set -x
 set -e
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "add_status 'error' 'DEPLOY FAILED'" TERM INT EXIT
+trap "set +x; add_status 'error' 'DEPLOY FAILED'" TERM INT EXIT
 set -x
 set -e
 

--- a/prepare-clusterapi.sh
+++ b/prepare-clusterapi.sh
@@ -3,6 +3,10 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
+trap "set +x; add_status 'error' 'PREPARE-CLUSTERAPI FAILED'; sleep 90" TERM INT EXIT
+set -e
+set -x
+
 export INTERACTIVE=false
 
 osism manage image clusterapi --filter 1.29

--- a/prepare.sh
+++ b/prepare.sh
@@ -3,6 +3,8 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
+trap "set +x; add_status 'error' 'PREPARE FAILED'; sleep 90" TERM INT EXIT
+
 set -x
 set -e
 

--- a/upgrade-manager.sh
+++ b/upgrade-manager.sh
@@ -3,6 +3,8 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
+trap "set +x; add_status 'error' 'MANAGER-UPGRADE FAILED'" TERM INT EXIT
+
 set -x
 set -e
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -3,6 +3,8 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
+trap "set +x; add_status 'error' 'UPGRADE FAILED'" TERM INT EXIT
+
 set -x
 set -e
 


### PR DESCRIPTION
If CIAB install fails, you are getting currently also the tracing output of the add_error function.

```
deploy | + osism apply kubernetes-dashboard
deploy | WARNING: OSISM CLI should not be used as root user
deploy | 
deploy | 2024-07-22 08:41:50 | INFO     | Task cbd4d748-83e4-42fb-ba0f-45dad86becf6 (kubernetes-dashboard) was prepared for execution.
deploy | 2024-07-22 08:41:50 | INFO     | It takes a moment until task cbd4d748-83e4-42fb-ba0f-45dad86becf6 (kubernetes-dashboard) has been started and output is visible here.
deploy | + add_status error 'DEPLOY FAILED'
deploy | + local type=error
deploy | + local 'text=DEPLOY FAILED'
deploy | + '[' error = warn ']'
deploy | + '[' error = info ']'
deploy | + text='\e[5;41;1mERROR: DEPLOY FAILED\e[0m'
deploy | + [[ error = \i\n\f\o ]]
deploy | + [[ -n /var/log/install-cloud-in-a-box.log ]]
deploy | + text='\e[5;41;1mERROR: DEPLOY FAILED\e[0m\n\nReview /var/log/install-cloud-in-a-box.log to analyze what went wrong'
deploy | + sudo cp /etc/issue.net /etc/.issue.net.backup
deploy | + sudo cp /etc/issue /etc/.issue.backup
deploy | + cat /etc/.issue.net.backup
deploy | + sudo tee /etc/issue.net
deploy | + echo -e '\e[5;41;1mERROR: DEPLOY FAILED\e[0m\n\nReview /var/log/install-cloud-in-a-box.log to analyze what went wrong'
deploy | + cat /etc/.issue.backup
deploy | + sudo tee /etc/issue
deploy | + echo -e '\e[5;41;1mERROR: DEPLOY FAILED\e[0m\n\nReview /var/log/install-cloud-in-a-box.log to analyze what went wrong'
```

This change makes the error output a bit more convenient to read.