### PR TITLE
Branch logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ deployment.
 For information how to install the Cloud in a Box, please have a look at the
 [Cloud in a Box Guide](https://osism.tech/docs/guides/other-guides/cloud-in-a-box).
 
+The development notes in the official documentation are useful for
+[bug fixes and the further development](https://osism.tech/docs/guides/other-guides/cloud-in-a-box/#development) of CiaB.
+
 ## Types
 
 There are three types of Cloud in a Box.

--- a/init.sh
+++ b/init.sh
@@ -42,6 +42,8 @@ set -e
 # Get initial configuration repository
 git clone "${ciab_repo_url:-https://github.com/osism/cloud-in-a-box}" /opt/cloud-in-a-box
 git -C /opt/cloud-in-a-box checkout "${ciab_branch:-main}"
+sed -i "~s,configuration_git_version:.*,configuration_git_version: ${ciab_branch:-main}," \
+   /opt/cloud-in-a-box/environments/manager/configuration.yml
 
 # Run bootstrap script
 /opt/cloud-in-a-box/bootstrap.sh $CLOUD_IN_A_BOX_TYPE


### PR DESCRIPTION
When selecting a branch different from "main" in the kernel-commandline a logic introduced a few weeks ago revokes the execution of run.sh.

```
bootstrap | + ./run.sh operator -e ansible_ssh_pass=password -e ansible_ssh_user=osism -e ansible_become_password=password
bootstrap | + set +x
ble-core~=2.16.5->ansible==9.4.0) (1.17.1)
bootstrap | Requirement already satisfied: pycparser in ./venv/lib/python3.10/site-packages (from cffi>=1.12->cryptography->ansible-core~=2.16.5->ansible==9.4.0) (2.22)
bootstrap | Installing collected packages: resolvelib, packaging, ansible-core, ansible
bootstrap | Successfully installed ansible-9.4.0 ansible-core-2.16.10 packaging-24.1 resolvelib-1.0.1
bootstrap | ERROR: Configured branch 'main' and current checkout-branch 'status_motd' are not the same!
bootstrap | (see /opt/cloud-in-a-box/environments/manager/configuration.yml, configuration_git_version)
```

This change, configures the desired path in the checkout : /opt/cloud-in-a-box/environments/manager/configuration.yml
