### PR TITLE
Only reference logfile when log level > info

### DIFF
--- a/include.sh
+++ b/include.sh
@@ -90,9 +90,7 @@ add_status(){
      text="\e[5;41;1mERROR: $text\e[0m"
    fi
 
-   if [[ "$type" = "info" ]] && [[ -n "$BOOTSTRAP_LOGFILE" ]];then
-       text="$text\n\nReview the progress in $BOOTSTRAP_LOGFILE"
-   elif [[ -n "$BOOTSTRAP_LOGFILE" ]];then
+   if [[ -n "$BOOTSTRAP_LOGFILE" ]];then
        text="$text\n\nReview $BOOTSTRAP_LOGFILE to analyze what went wrong"
    fi
 


### PR DESCRIPTION
This avois duplication entries like in this sample.

```
Last login: Sun Sep 29 15:50:41 2024 from 127.0.0.1

INFO: BOOTSTRAP COMPLETE

Review the progress in /var/log/install-cloud-in-a-box.log
INFO: DEPLOYMENT COMPLETED SUCCESSFULLY

Review the progress in /var/log/install-cloud-in-a-box.log
```