### PR TITLE
Keep cloud-init, only disable it

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -140,5 +140,7 @@ osism apply clusterapi
 osism apply copy-kubeconfig
 osism apply magnum
 
+touch /etc/cloud/cloud-init.disabled
+
 trap "" TERM INT EXIT
 add_status info "DEPLOYMENT COMPLETED SUCCESSFULLY"

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -41,6 +41,7 @@ hosts_additional_entries:
 ##########################
 # common
 
+cleanup_cloudinit: false
 cleanup_services_extra:
   - NetworkManager
   - iscsid


### PR DESCRIPTION
It's not possible to uninstall cloud-init because cloud-init is still in use at this point.

Related to 07e6727a34fb1f188a5fc803de784a1bf518661d