### PR TITLE
Remove hosts_type parameter

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -37,7 +37,6 @@ resolvconf_dnssec: false
 ##########################
 # hosts
 
-hosts_type: template
 hosts_additional_entries:
   api.in-a-box.cloud: 192.168.16.254
 


### PR DESCRIPTION
hosts_type = template is the default value in OSISM.