### PR TITLE
nova: set cpu_allocation_ratio = 3.0

### DIFF
--- a/environments/kolla/files/overlays/nova/nova-compute.conf
+++ b/environments/kolla/files/overlays/nova/nova-compute.conf
@@ -1,7 +1,7 @@
 [DEFAULT]
 resume_guests_state_on_host_boot = true
 
-cpu_allocation_ratio = 4.0
+cpu_allocation_ratio = 3.0
 ram_allocation_ratio = 1.0
 disk_allocation_ratio = 1.0
 


### PR DESCRIPTION
Closes osism/cloud-in-a-box#238
Related to osism/issues#902