### PR TITLE
Add timestamps and START/COMPLETE status messages to deployment scripts

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -138,4 +138,4 @@ if [[ $CLOUD_IN_A_BOX_TYPE != "kubernetes" ]]; then
 fi
 
 trap "" TERM INT EXIT
-add_status "info" "BOOTSTRAP COMPLETE"
+add_status "info" "BOOTSTRAP COMPLETED"

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,12 +3,14 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "set +x; add_status 'error' 'DEPLOY FAILED'; sleep 90" TERM INT EXIT
+trap "set +x; add_status 'error' 'DEPLOYMENT FAILED'; sleep 90" TERM INT EXIT
 set -x
 set -e
 
 export INTERACTIVE=false
 export OSISM_APPLY_RETRY=1
+
+add_status "info" "DEPLOYMENT STARTED"
 
 if [[ -e /etc/cloud-in-a-box.env ]]; then
     source /etc/cloud-in-a-box.env
@@ -44,7 +46,7 @@ if [[ $CLOUD_IN_A_BOX_TYPE == "kubernetes" ]]; then
     /opt/configuration/enable-ara.sh
 
     trap "" TERM INT EXIT
-    add_status info "DEPLOYMENT COMPLETED SUCCESSFULLY"
+    add_status info "DEPLOYMENT COMPLETED"
 
     exit 0
 fi
@@ -161,4 +163,4 @@ touch /etc/cloud/cloud-init.disabled
 /opt/configuration//enable-ara.sh
 
 trap "" TERM INT EXIT
-add_status info "DEPLOYMENT COMPLETED SUCCESSFULLY"
+add_status info "DEPLOYMENT COMPLETED"

--- a/include.sh
+++ b/include.sh
@@ -84,13 +84,14 @@ get_default_dns_servers() {
 add_status(){
    local type="$1"
    local text="$2"
+   local timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
    if [ "$type" = "warn" ];then
-     text="\e[5;43;1mWARN: $text\e[0m"
+     text="${timestamp} \e[5;43;1mWARN: $text\e[0m"
    elif [ "$type" = "info" ];then
-     text="\e[5;42;1mINFO: $text\e[0m"
+     text="${timestamp} \e[5;42;1mINFO: $text\e[0m"
    else
-     text="\e[5;41;1mERROR: $text\e[0m"
+     text="${timestamp} \e[5;41;1mERROR: $text\e[0m"
    fi
 
    sudo cp /etc/issue.net /etc/.issue.net.backup

--- a/prepare-clusterapi.sh
+++ b/prepare-clusterapi.sh
@@ -3,11 +3,13 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "set +x; add_status 'error' 'PREPARE-CLUSTERAPI FAILED'; sleep 90" TERM INT EXIT
+trap "set +x; add_status 'error' 'PREPARE CLUSTERAPI FAILED'; sleep 90" TERM INT EXIT
 set -e
 set -x
 
 export INTERACTIVE=false
+
+add_status "info" "PREPARE CLUSTERAPI STARTED"
 
 osism manage image clusterapi --filter 1.33
 
@@ -27,3 +29,6 @@ openstack --os-cloud admin coe cluster template create \
   --coe kubernetes \
   --label kube_tag=v$KUBERNETES_VERSION \
   k8s-$KUBERNETES_VERSION
+
+trap "" TERM INT EXIT
+add_status "info" "PREPARE CLUSTERAPI COMPLETED"

--- a/upgrade-manager.sh
+++ b/upgrade-manager.sh
@@ -3,13 +3,15 @@
 BASE_DIR="$(dirname $(readlink -f $0))"
 source $BASE_DIR/include.sh
 
-trap "set +x; add_status 'error' 'MANAGER-UPGRADE FAILED'" TERM INT EXIT
+trap "set +x; add_status 'error' 'MANAGER UPGRADE FAILED'" TERM INT EXIT
 
 set -x
 set -e
 
 export INTERACTIVE=false
 source /etc/cloud-in-a-box.env
+
+add_status "info" "MANAGER UPGRADE STARTED"
 
 # The normal way of updating the configuration repository (osism sync configuration)
 # is not used as we have made manual changes in the configuration repository
@@ -21,3 +23,6 @@ popd
 osism update manager
 
 osism apply cleanup-docker-images -e ireallymeanit=yes
+
+trap "" TERM INT EXIT
+add_status "info" "MANAGER UPGRADE COMPLETED"


### PR DESCRIPTION
Enhanced the add_status function and deployment scripts with better status tracking:

- add_status: Add timestamp prefix (YYYY-MM-DD HH:MM:S) to all status messages
  * Timestamp is uncolored for better readability
  * Status labels (INFO/WARN/ERROR) remain colored as before

- deploy.sh: Add DEPLOYMENT STARTED message at script start
  * Standardize completion message to "DEPLOYMENT COMPLETE"

- upgrade-manager.sh: Add full status tracking
  * Add MANAGER UPGRADE STARTED message
  * Add MANAGER UPGRADE COMPLETE message with proper trap clearing

- prepare-clusterapi.sh: Add full status tracking
  * Add PREPARE CLUSTERAPI STARTED message
  * Add PREPARE CLUSTERAPI COMPLETE message with proper trap clearing

All status messages now include timestamps for better tracking and debugging of deployment processes.

AI-assisted: Claude Code