### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/inventory/99-overwrite
+++ b/inventory/99-overwrite
@@ -4,9 +4,9 @@
 # This applies to both the form with :children and without.
 #
 # All predefined and usable inventory groups can be found
-# in the cfg-generics repository.
+# in the generics repository.
 #
-# https://github.com/osism/cfg-generics/tree/main/inventory
+# https://github.com/osism/generics/tree/main/inventory
 
 [ceph-rgw:children]
 ceph-resource


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update the explanatory comment in `inventory/99-overwrite` to match.

## Test plan
- [ ] Visual inspection — comment now references `osism/generics`