### PR TITLE
Retry container image pull on transient errors

### DIFF
--- a/environments/custom/playbook-pull-container-images.yml
+++ b/environments/custom/playbook-pull-container-images.yml
@@ -47,3 +47,7 @@
         - "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
         - "{{ docker_registry_cephclient }}/osism/cephclient:{{ cephclient_version }}"
         - "{{ docker_registry_openstackclient }}/osism/openstackclient:{{ openstackclient_version }}"
+      register: result
+      until: result is success
+      retries: 3
+      delay: 30


### PR DESCRIPTION
## What

Add a retry to the second `Pull container images` task in
`environments/custom/playbook-pull-container-images.yml`.

```yaml
      community.docker.docker_image:
        name: "{{ item }}"
        source: pull
      loop:
        - "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_image_version }}"
        - "{{ docker_registry_cephclient }}/osism/cephclient:{{ cephclient_version }}"
        - "{{ docker_registry_openstackclient }}/osism/openstackclient:{{ openstackclient_version }}"
      register: result
      until: result is success
      retries: 3
      delay: 30
```

## Why

Same class of failure as:

- osism/ansible-collection-services#2150
- osism/container-image-ceph-ansible#708

The task had no retry, so a single transient registry error failed it and with it
the whole `pull-container-images` action — which both `deploy.sh` and
`upgrade.sh` run (`osism apply -e custom pull-container-images`).

The Ceph image comes from `ceph_docker_registry`, which defaults to `quay.io`: a
third-party registry OSISM does not control and which returns transient 5xx
errors.

Notably the task directly above it already retries — it shells out to
`osism apply -r 2 -a pull` — so the retry-less task was the odd one out inside its
own playbook.

## Why the explicit `until` form

The bare `retries:` / `delay:` form used elsewhere in OSISM relies on ansible-core
falling back to an implicit condition on the task not having failed when `until` is
unset. That fallback was only introduced in **2.16**; in 2.15 the retry block is
gated behind `if self._task.until:`, so `retries` stays 1 and a bare `retries:` is
a silent no-op.

`osism-ansible` pins ansible-core 2.18.18 today, so the bare form would work here —
but releases 6.0.0 and 6.0.1 pinned 2.15, so the explicit form keeps this
independent of the image it happens to run in, and consistent with #708.

## Verification

This task has a `loop`, unlike the sibling pull sites, so the loop interaction was
measured rather than assumed. Probe: a three-item loop where only the middle item
fails.

| Item | Result | Executions |
|---|---|---|
| first (succeeds) | ok | 1 |
| second (always fails) | failed after retries | 4 |
| third (succeeds, runs after the failure) | ok | 1 |

So `until`/`retries` apply **per item**: a flaky image is retried on its own and
does not cause the other images to be re-pulled, and a succeeding item following a
failed one is not affected by a stale register.

Also confirmed that `retries: 3` means 4 real executions on both 2.15.13 and
2.16.19 by counting actual invocations — ansible reports `attempts: 3` for the
same run, which is a reporting quirk, not 3 executions.

Lint, over the staged file:

- `yamllint` (the repo's `.yamllint.yml`, via the `yamllint` Zuul job) — pass
- `ansible-lint` with the custom OSISM rules — `0 failure(s), 0 warning(s) in 1
  files processed`, last profile met `production`

## Risk

Low. On success the task behaves exactly as before. On failure it now takes up to
90s longer per affected image before failing the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
